### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of the bug.
+
+**Reference Links, optional**
+Is there a GitHub issue or Slack thread with more details?
+
+**Issue Priority, optional**
+- [ ] Low
+- [ ] Medium
+- [ ] High
+
+**Environment, optional**
+- Python version:
+- coiled-runtime version:
+If not using coiled-runtime, then:
+- Dask version:
+- Coiled version:
+
+**Diagnostics, optional**
+Please run `coiled.diagnostics` locally and paste the result below:
+
+<details>
+<summary>Coiled Diagnostics Output:</summary>
+
+</details>
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/general-feedback.md
+++ b/.github/ISSUE_TEMPLATE/general-feedback.md
@@ -1,0 +1,16 @@
+---
+name: General feedback
+about: Feature requests, suggestions, usability issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
@phobson I created a couple templates for creating bug reports and submitting feedback, based on the current dask/dask issue templates, the (soon to be RIP) [feedback template](https://docs.coiled.io/user_guide/feedback.html) and the [support template](https://support.coiled.io/hc/en-us/requests/new).